### PR TITLE
chore: remove unnecessary checkout step

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -15,7 +15,6 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
       - uses: vexxhost/docker-atmosphere/.github/actions/build-image@main
         with:
           image-name: netoffload


### PR DESCRIPTION
## Summary
- Remove the checkout step from image workflow
- Depot fetches from the git context automatically when no explicit context is specified

## Test plan
- [ ] Verify image builds successfully on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)